### PR TITLE
RSA constructor should take an optional second argument

### DIFF
--- a/lib/keystores/jks/pkcs8_key.rb
+++ b/lib/keystores/jks/pkcs8_key.rb
@@ -60,10 +60,10 @@ module OpenSSL
     class RSA
       original_initialize = instance_method(:initialize)
 
-      define_method(:initialize) do |der_or_pem|
+      define_method(:initialize) do |der_or_pem, pass_phrase = nil|
         init = original_initialize.bind(self)
         begin
-          init.(der_or_pem)
+          init.(der_or_pem, pass_phrase)
         rescue Exception
           # If we blow up trying to parse the key, we might be der encoded PKCS8, and if we are, convert ourselves
           # to PEM and try again.


### PR DESCRIPTION
give2charity uses OpenSSL::RSA with the two-argument constructor, so the overridden constructor should support this too, since there is no workaround to pass in the passphrase other than manual input.